### PR TITLE
Replace bashtop with btop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -358,7 +358,7 @@
 #### System Monitors
 
 - [Atop](https://github.com/Atoptool/atop) - System and process monitor for Linux. (C)
-- [bashtop](https://github.com/aristocratos/bashtop) - Linux/OSX/FreeBSD resource monitor (bash)
+- [btop](https://github.com/aristocratos/btop) - Linux/OSX/FreeBSD resource monitor (C++)
 - [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor. (rust)
 - [Glances](https://github.com/nicolargo/glances) - Glances an Eye on your system. A top/htop alternative. (python)
 - [Gotop](https://github.com/cjbassi/gotop) - A terminal based graphical activity monitor inspired by gtop and vtop. (go,C)

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 	</div>
 	<br>
 	<p> A curated list of awesome tools and technologies to make your Operating System look beautiful ❤️ </p>
-	<img src="https://awesome.re/badge.svg" alt="Awesome Badge">
+	<img src="https://awesome.re/badge.svg" alt="Awesome Badage">
 </div>
 
 ## Table of Contents
@@ -358,6 +358,7 @@
 #### System Monitors
 
 - [Atop](https://github.com/Atoptool/atop) - System and process monitor for Linux. (C)
+- [bashtop](https://github.com/aristocratos/bashtop) - Linux/OSX/FreeBSD resource monitor (bash)
 - [btop](https://github.com/aristocratos/btop) - Linux/OSX/FreeBSD resource monitor (C++)
 - [bottom](https://github.com/ClementTsang/bottom) - Yet another cross-platform graphical process/system monitor. (rust)
 - [Glances](https://github.com/nicolargo/glances) - Glances an Eye on your system. A top/htop alternative. (python)


### PR DESCRIPTION
The author of bashtop recommended using [bpytop](https://github.com/aristocratos/bpytop) over bashtop and now bpytop itself has been superseded by a C++ rewrite, [btop++](https://github.com/aristocratos/btop). 