### PR TITLE
Remove Aminal

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -229,7 +229,6 @@
 
 #### Linux
 
-- [Aminal](https://github.com/liamg/aminal) - Golang terminal emulator from scratch. (go)
 - [cool-retro-term](https://github.com/Swordfish90/cool-retro-term) - A good looking terminal emulator which mimics the old cathode display. (qml)
 - [darktile](https://github.com/liamg/darktile) - a GPU rendered terminal emulator designed for tiling window managers. (go)
 - [deepin-terminal](https://github.com/linuxdeepin/deepin-terminal) - Terminal for deepin DE. (C++)


### PR DESCRIPTION
Aminal is now called Darktile (which is already on the list)