### PR TITLE
Add yabai under Tiling WMs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@
       - [Tiling wms](#tiling-wms)
       - [Stacking and floating wms](#stacking-and-floating-wms)
       - [Dynamic tiling wms](#dynamic-tiling-wms)
+      - [MacOS wms](#macos-wms)
   - [Show off scripts](#show-off-scripts)
   - [Terminals](#terminals)
     - [Other](#other)
@@ -83,7 +84,6 @@
 - [wmderland](https://github.com/aesophor/wmderland) - X11 tiling window manager using space partitioning trees .(C++)
 - [wmii](https://github.com/0intro/wmii) - A small, scriptable window manager, with a 9P filesystem interface and an acme-like layout. (C)
 - [xoat](https://github.com/seanpringle/xoat) - An obstinate, asymmetric, tiling, window manager for X. (C)
-- [yabai](https://github.com/koekeishiya/yabai) - A tiling window manager for macOS based on binary space partitioning. (C)
 
 ##### Stacking and floating wms
 
@@ -156,7 +156,12 @@
 - [velox](https://github.com/michaelforney/velox) - Window manager inspired by dwm and xmonad. (C)
 - [wingo](https://github.com/BurntSushi/wingo) - A fully-featured window manager. (go)
 - [wzrd](https://github.com/deurzen/wzrd) - An ICCCM & EWMH compliant X11 reparenting, dynamic window manager. (rust)
-- [xmonad](https://github.com/xmonad/xmonad) - a small but functional ICCCM-compliant tiling window manager . (Haskell)
+- [xmonad](https://github.com/xmonad/xmonad) - a small but functional ICCCM-compliant tiling window manager . (Haskell)  
+
+##### MacOS wms
+
+- [yabai](https://github.com/koekeishiya/yabai) - A tiling window manager for macOS based on binary space partitioning. (C)
+- [Amethyst](https://github.com/ianyh/Amethyst) - Automatic tiling window manager for macOS à la xmonad. (Swift)
 
 #### Other
 

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@
 - [wmderland](https://github.com/aesophor/wmderland) - X11 tiling window manager using space partitioning trees .(C++)
 - [wmii](https://github.com/0intro/wmii) - A small, scriptable window manager, with a 9P filesystem interface and an acme-like layout. (C)
 - [xoat](https://github.com/seanpringle/xoat) - An obstinate, asymmetric, tiling, window manager for X. (C)
+- [yabai](https://github.com/koekeishiya/yabai) - A tiling window manager for macOS based on binary space partitioning. (C)
 
 ##### Stacking and floating wms
 


### PR DESCRIPTION
Yabai is arguably one of the most extensive and popular tiling window manager for MacOS (both intel and arm based architectures). Supports many of the same features as i3.