### PR TITLE
add ramfetch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -405,6 +405,7 @@
 - [Hilbifetch](https://github.com/Hilbis/Hilbifetch) - Simple and small fetch. (lua)
 - [Hyperfetch](https://github.com/ralseiii/hyperfetch) - a multi-threaded system information tool written in posix sh. (shell)
 - [Kat-OH](https://github.com/70xH/Kat-OH) - A huge fetch. (go)
+- [ramfetch](https://github.com/gentoo-btw/ramfetch) - a fetch which displays memory info using /proc/meminfo. (shell)
 - [lfetch](https://github.com/TheUpBeat/lfetch) - Yet another fetch program. (C)
 - [fastfetch](https://github.com/LinusDierheimer/fastfetch) - Like neofetch, but much faster because written in c. Only Linux. (c)
 - [ferris-fetch](https://github.com/irevenko/ferris-fetch) - A system information tool for Rustaceans.(rust)


### PR DESCRIPTION
so i made a fetch tool (once again) called ramfetch. it displays memory info using /proc/meminfo. im not sure if this can be added into this repo. as this fetch just prints ram stuff.

preview:
![image](https://user-images.githubusercontent.com/119129086/207656587-932af305-1047-41a9-8c26-afdd207e320b.png)

some ppl told me in r/linux to add commas, others just asked to add more info. 
it got 40 clones and 90 vistors. and i kept getting downvoted in my r/linux post. (maybe bc r/linux doesn't like fetch tools) y'know there is horrible fetches like sfetch, yfetch, tinyfetch and others. that are poorly written in bash. but ramfetch got 10 stars and 2 forks (1 of them still in work for now) and it's more stars than i got than any other project i made. 